### PR TITLE
crossing-7069 SD card reader booting disable

### DIFF
--- a/.kitchen.vagrant.yml
+++ b/.kitchen.vagrant.yml
@@ -11,7 +11,7 @@ provisioner:
   require_chef_for_busser: false
   require_ruby_for_busser: false
   ansible_verbose: true
-  roles_path: ../ansible-os-hardening/
+  roles_path: ../ansible-role-os-hardening/
   playbook: default.yml
 
 platforms:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -17,7 +17,7 @@ provisioner:
   ansible_verbose: true
   ansible_diff: true
   hosts: all
-  roles_path: ../ansible-os-hardening/
+  roles_path: ../ansible-role-os-hardening/
   playbook: default.yml
   ansible_extra_flags:
     - "--skip-tags=sysctl"

--- a/default.yml
+++ b/default.yml
@@ -1,8 +1,8 @@
 ---
-- name: wrapper playbook for kitchen testing "ansible-os-hardening" with custom vars for testing
+- name: wrapper playbook for kitchen testing "ansible-role-os-hardening" with custom vars for testing
   hosts: localhost
   roles:
-    - ansible-os-hardening
+    - ansible-role-os-hardening
   vars:
     os_security_users_allow: change_user
     os_security_kernel_enable_core_dump: true
@@ -15,7 +15,7 @@
     os_security_suid_sgid_blacklist: ['/bin/umount']
     os_security_suid_sgid_whitelist: ['/usr/bin/rlogin']
 
-- name: wrapper playbook for kitchen testing "ansible-os-hardening"
+- name: wrapper playbook for kitchen testing "ansible-role-os-hardening"
   hosts: localhost
   roles:
-    - ansible-os-hardening
+    - ansible-role-os-hardening

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -144,7 +144,7 @@ sysctl_rhel_config:
   net.ipv4.tcp_synack_retries: 2
   net.ipv4.tcp_syn_retries: 5
 
-blacklist_modules: ["cramfs", "freevxfs", "jffs2", "hfs", "hfsplus", "squashfs", "udf", "vfat", "dccp", "sctp", "rds", "tipc", "usb-storage", "uas", "bluetooth"]
+blacklist_modules: ["rtsx_pci","cramfs", "freevxfs", "jffs2", "hfs", "hfsplus", "squashfs", "udf", "vfat", "dccp", "sctp", "rds", "tipc", "usb-storage", "uas", "bluetooth"]
 
 # Lightdm restrictions
 greeter_show_manual_login: "true"

--- a/spec/travis.yml
+++ b/spec/travis.yml
@@ -1,3 +1,3 @@
 - hosts: localhost
   roles:
-    - ansible-os-hardening
+    - ansible-role-os-hardening


### PR DESCRIPTION
SD cards can not be read by any EUDs.
ansible role OS-Hardening has been updated.
=================================================
defaults/main.yml (added the module in blacklist_modules )and spec/travis.yml files(changed the role name to "ansible--role-os-hardening" ) I have modified.

But I have done changes in .kitchen.vagrant.yml ,.kitchen.yml and default.yml  .
which were earlier with "ansible-os-hardening "  ,I have updated it with ansible--role-os-hardening .

After the above change ,run the scripts in travis.yml ,and result is as expected.

